### PR TITLE
Make compose file directory default

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,10 @@ the script after its initialisation has performed. In other words, variables
 such as [`BUILD_BUILDER`](#option--b-and-build_builder-variable) will reflect
 the builder that is about to be used.
 
-The default for this variable are the directories named
-[`build-init.d`](./build-init.d/README.md) in the current directory, and the
-directory containing the script.
+The default for this variable is the special character `-`. It will
+automatically be resolved to the directory named
+[`build-init.d`](./build-init.d/README.md) in the same directory as the compose
+file, and the directory [containing](#build_rootdir-variable) the script.
 
 ### Option `-c` and `BUILD_CLEANUP_DIR` Variable
 
@@ -217,9 +218,11 @@ actions, similarily to the [`-i`](#option--i-and-build_init_dir-variable)
 option. In addition, cleanup actions can know about built and/or pushed images
 through the [`BUILD_IMAGES`](#build_images-variable) variable.
 
-The default for this variable are the directories named
-[`build-cleanup.d`](./build-cleanup.d/README.md) in the current directory, and
-the directory containing the script.
+The default for this variable is the special character `-`. It will
+automatically be resolved to the directory named
+[`build-cleanup.d`](./build-cleanup.d/README.md) in the same directory as the
+compose file, and the directory [containing](#build_rootdir-variable) the
+script.
 
 ### `BUILD_COMPOSE_BIN` Variable
 

--- a/build-cleanup.d/README.md
+++ b/build-cleanup.d/README.md
@@ -1,13 +1,13 @@
 # Cleanup Directory
 
 By default any executable present in this directory, or the directory named
-similarily, but in the current directory where the script is started from, will
-be automatically executed once the [`build.sh`](../build.sh) script has build
-and/or pushed all images. All variables starting with the prefix `BUILD_` are
-exported to the executables. The content of these variables will reflect exactly
-how the [`build.sh`](../build.sh) script has behaved: for example,
-`BUILD_BUILDER` will be the builder that will effectively be used after all
-checks have been performed.
+similarily, but in the same directory as the compose file, will be automatically
+executed once the [`build.sh`](../build.sh) script has build and/or pushed all
+images. All variables starting with the prefix `BUILD_` are exported to the
+executables. The content of these variables will reflect exactly how the
+[`build.sh`](../build.sh) script has behaved: for example, `BUILD_BUILDER` will
+be the builder that will effectively be used after all checks have been
+performed.
 
 A variable called `BUILD_IMAGES` is also passed further to cleanup programs. The
 variable contains the space-separated list of images that were built, or the

--- a/build-init.d/README.md
+++ b/build-init.d/README.md
@@ -1,10 +1,10 @@
 # Initialisation Directory
 
 By default any executable present in this directory, or the directory named
-similarily, but in the current directory where the script is started from, will
-be automatically executed once the [`build.sh`](../build.sh) script has
-initialised, just before it starts building and pushing. All variables starting
-with the prefix `BUILD_` are exported to the executables. The content of these
-variables will reflect exactly how the [`build.sh`](../build.sh) script will
-behave: for example, `BUILD_BUILDER` will be the builder that will effectively
-be used after all checks have been performed.
+similarily, but in same directory as the compose file, will be automatically
+executed once the [`build.sh`](../build.sh) script has initialised, just before
+it starts building and pushing. All variables starting with the prefix `BUILD_`
+are exported to the executables. The content of these variables will reflect
+exactly how the [`build.sh`](../build.sh) script will behave: for example,
+`BUILD_BUILDER` will be the builder that will effectively be used after all
+checks have been performed.


### PR DESCRIPTION
This arranges for the directory containing the docker-compose file to
be used in a number of places by default. This change is in line with
how, for example, build contexts work.