### PR TITLE
GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # docker-compose-build
 
 Using `docker-compose` in dev, but a more complex orchestrator in production?
-This script uses the (Docker) [compose] file to capture building information for
-your images, but can help out when pushing to several registries or tagging them
-with a release number (from a GitHub workflow?), for example. The script
-supplements and/or replaces `docker compose build` with `docker build` in order
-to:
+This [script](#command-line-and-environment-configuration) (and GitHub
+[action](#github-action)) uses the (Docker) [compose] file to capture building
+information for your images, but can help out when pushing to several registries
+or tagging them with a release number (from a GitHub workflow?), for example.
+The script supplements and/or replaces `docker compose build` with `docker
+build` in order to:
 
 + [Push](#option--b-and-build_builder-variable) the resulting image(s) to their
   registries.
@@ -268,6 +269,29 @@ any way. It is passed further to cleanup programs at the end. The variable
 contains the space-separated list of images that were built, or the list of
 images that were pushed. When images were requested to be built and pushed, only
 the list of pushed images will be present.
+
+## GitHub Action
+
+The script doubles as a GitHub Action, use it in a workflow as exemplified
+below, provided you have access to `docker`. For a complete list of inputs and
+their usage, consult the [`action.yml`](./action.yml) file.
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and Push
+        uses: Mitigram/docker-compose-build@main
+        with:
+          compose: <path-to-compose.yml>
+```
+
+Note that by default, the action attempts to make all the binaries available at
+their standard location under the extraction directory at the `PATH`. In other
+words, the default behaviour of the action is to leverage the behaviour of the
+[`-e`](#flag--e) flag. You can turn off this behaviour by setting the input
+called `path` to the string `"false"`.
 
 ## Future
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This [script](#command-line-and-environment-configuration) (and GitHub
 [action](#github-action)) uses the (Docker) [compose] file to capture building
 information for your images, but can help out when pushing to several registries
 or tagging them with a release number (from a GitHub workflow?), for example.
-The script supplements and/or replaces `docker compose build` with `docker
-build` in order to:
+The script supplements and/or replaces `docker compose build` with
+`docker build` in order to:
 
 + [Push](#option--b-and-build_builder-variable) the resulting image(s) to their
   registries.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ the compose file will be picked up and used, if any.
 
 ### Option `-r` and `BUILD_REGISTRY` Variable
 
-Specified an alternative registry to use instead of the one specified as part of
+Specifies an alternative registry to use instead of the one specified as part of
 the compose file. When no registry is given, the default, the registry will be
 the one from the compose file.
 
@@ -255,10 +255,11 @@ the triggering script, if necessary.
 
 ### `BUILD_DOWNLOADER` Variable
 
-Specifies the command used to download release information from GitHub. This
-command should take an additional argument, the URL to download and dump the
-content of the URL to `stdout`. When empty, the default, one of `curl` or
-`wget`, if present, will be used.
+Specifies the command used to download release information from GitHub. When run
+the command specified in this variable will be given an additional argument, the
+URL to download and it should dump the content of the URL to `stdout` as a
+result. When empty, the default, one of `curl` or `wget`, if present, will be
+used. When a dash `-`, version checks will be skipped.
 
 ### `BUILD_IMAGES` Variable
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,158 @@
+name: Compose Build
+description: |
+  Build from compose file, with additional features such as changing destination
+  registry or tag, or run pre-build and/or post-push hooks.
+author: Emmanuel Frecon <emmanuel.frecon@mitigram.com>
+branding:
+  icon: layers
+  color: green
+
+inputs:
+  compose:
+    description: Path to the compose file
+    required: true
+
+  push:
+    description: |
+      When true, images specified by the compose file will also be pushed to
+      their respective registries, once building has finished. The `docker`
+      client used in the workflow must have enough credentials to access the
+      remote registries. Old images will automatically be skipped (see input
+      `age`)
+    required: false
+    default: "true"
+
+  builder:
+    description: |
+      Specifies the builder to use, can be one of:
+
+      + `compose` (the default): will try hard to use compose, but will revert
+        to the `auto` builder (see below) when `docker-compose` is not
+        installed.
+      + `auto`: will pick the best of the new `buildx` or old-style `docker
+        build`, depending on which is available, and in that order, i.e.
+        `buildx` preferred.
+      + `buildx`: will use the new `buildx` for building. This requires the
+        `buildx` Docker plugin to be available and properly installed.
+      + `docker` or `build`: will use the old-style `docker build` command.
+    required: false
+    default: compose
+
+  services:
+    description: |
+      Specifies the space separated list of services to build. These services
+      need to exist in the compose file. When empty, the default, the action
+      will default to building/pushing all the services specified in the compose
+      file.
+    required: false
+
+  tags:
+    description: |
+      Specifies the space separated list of tags to give to the images that will
+      be built/pushed. When building, the image with the first tag in the list
+      will be built, while images with the other tags will be tagged with the
+      first image as the source. The default is to not specified any tag, in
+      which case the tag from the compose file will be picked up and used, if
+      any.
+    required: false
+
+  registry:
+    description: |
+      Specifies an alternative registry to use instead of the one specified as
+      part of the compose file. When no registry is given, the default, the
+      registry will be the one from the compose file.
+    required: false
+
+  age:
+    description: |
+      Specifies the maximum age (in seconds) of the image since creation to
+      decide whether it should be pushed or not. This is a safety measure to
+      avoid pushing junk images have not been changed during build. The default
+      of `1200` seconds should work in most cases, but any negative value will
+      turn this check off, meaning that all relevant images will be pushed,
+      disregarding their age.
+    required: false
+    default: "1200"
+
+  init:
+    description: |
+      Specifies a list of directory paths, separated by the colon `:` sign
+      wherefrom to find and execute initialisation actions. All exectuable
+      (scripts or programs) in these directories will automatically be executed
+      once the action initialisation has ended and before build and push
+      operations are about to start. See main README.md for more information
+    required: false
+    default: "-"
+
+  cleanup:
+    description: |
+      Specifies a list of directory paths, separated by the colon `:` sign
+      wherefrom to find and execute cleanup actions. All exectuable (scripts or
+      programs) in these directories will automatically be executed once images
+      have been built and pushed. See main README.md for more information
+    required: false
+    default: "-"
+
+  options:
+    description: |
+      Additional options to build implementation script, e.g. -v to print out
+      additional verbose information. This is a semi-internal input and should
+      only be used for debugging. If led by a double-dash, the value to this
+      input can be used to pass further option to the build commands, e.g.
+      `-- --no-cache`.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # Make sure that we have all the binaries necessary to run the image, we
+    # need at least a Docker CLI client (even though this isn't **strictly**
+    # necessary, e.g. nerdctl, but out of the scope of the action)
+    -
+      name: Check binary Dependencies
+      id: dependencies
+      uses: Mitigram/gh-action-dependency-check@main
+      with:
+        dependencies: |
+          docker
+    -
+      name: Build
+      id: build
+      shell: bash
+      if: ! inputs.push
+      # Action syntax forces either version, or tag from `use`, so disable
+      # download check.
+      env:
+        BUILD_DOWNLOADER: "-"
+      run: |
+        ${{ github.action_path }}/build.sh \
+          -f '${{ inputs.compose }}' \
+          -b '${{ inputs.builder }}' \
+          -s '${{ inputs.services }}' \
+          -t '${{ inputs.tags }}' \
+          -r '${{ inputs.registry }}' \
+          -i '${{ inputs.init }}' \
+          -c '${{ inputs.cleanup }}' \
+          ${{ inputs.options }}
+    -
+      name: Build and Push
+      id: push
+      shell: bash
+      if: inputs.push
+      # Action syntax forces either version, or tag from `use`, so disable
+      # download check.
+      env:
+        BUILD_DOWNLOADER: "-"
+      run: |
+        ${{ github.action_path }}/build.sh \
+          -f '${{ inputs.compose }}' \
+          -b '${{ inputs.builder }}' \
+          -s '${{ inputs.services }}' \
+          -t '${{ inputs.tags }}' \
+          -r '${{ inputs.registry }}' \
+          -i '${{ inputs.init }}' \
+          -c '${{ inputs.cleanup }}' \
+          -a '${{ inputs.age }}' \
+          -p \
+          ${{ inputs.options }}

--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,8 @@ BUILD_CLEANUP_DIR=${BUILD_CLEANUP_DIR:-"-"}
 
 # Command to use to download stuff. This command should take an additional
 # argument, the URL to download and dump the content of the URL to the stdout.
-# When empty, the default, one of curl or wget, if present, will be used.
+# When empty, the default, one of curl or wget, if present, will be used. When a
+# dash, version check will be disabled.
 BUILD_DOWNLOADER=${BUILD_DOWNLOADER:-}
 
 # Name of the project at GitHub, there is is little point in changing this...
@@ -660,7 +661,7 @@ execute "$BUILD_CLEANUP_DIR" "cleanup"
 #########
 # STEP 6: Check for New Versions
 #########
-if [ -n "$BUILD_DOWNLOADER" ]; then
+if [ -n "$BUILD_DOWNLOADER" ] && [ "$BUILD_DOWNLOADER" != "-" ]; then
   verbose "Checking latest version of project $BUILD_GH_PROJECT at GitHub"
   # Pick the latest release out of the HTML for the releases description. This
   # avoids the GitHub API on purpose to avoid being rate-limited.

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ pathfind() {
 }
 
 # Version of script, this should be increased for each new release of the script
-BUILD_VERSION=1.4.2
+BUILD_VERSION=1.5.0-beta
 
 # The location of the compose file. This file contains information about the
 # images to generate.


### PR DESCRIPTION
This adds GH action YAML in order to make the script usable as a GitHub action. When used as an action, the tag or version will be specified from the calling workflow, so version checks are skipped.