### PR TITLE
Implement `push` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,11 @@ long as they implement a `docker`-compatible CLI interface, e.g. [img] or
 the `build` command of `docker-compose`, to the specific set of options
 supported by the `build` command of the `docker`, `img` and `nerdctl` apps.
 
+To install the shim as `docker-compose`, you can make a copy of this project
+under `$HOME/.local/share/docker-compose-build` and create a symbolic link to
+the `compose.sh` script from `$HOME/.local/bin/docker-compose` (and arrange for
+`$HOME/.local/bin` to be first in your `$PATH`).
+
   [img]: https://github.com/genuinetools/img
   [nerdctl]: https://github.com/containerd/nerdctl
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ line. This is to facilitate automation. All other output (logging, output of
 `docker` or `docker-compose`, etc.) is redirected to `stderr`.
 
 The project even implements a [replacement](#docker-compose-shim) for
-`docker-compose build`, with a similar UX at the CLI (i.e. same set of options
-and flags).
+`docker-compose` `build` (and `push`), with a similar UX at the CLI (i.e. same
+set of options and flags).
 
 To use this script in your projects, you can either make this project a
 [submodule] or [subtree] of your main project. The script will print a warning
@@ -312,11 +312,14 @@ jobs:
 ## `docker-compose` Shim
 
 In addition, this project contains a [shim](./compose.sh) that is able to
-entirely **replace** `docker-compose build`. The shim can be installed and
-called `docker-compose` at the OS level and used to build Docker images directly
-with the `docker` client, bypassing `docker-compose` entirely. This can be
-usefull to use alternative projects for building Docker images, as long as they
-implement a `docker`-compatible CLI interface, e.g. [img] or [nerdctl].
+entirely **replace** `docker-compose` `build` (and `push`). The shim can be
+installed and called `docker-compose` at the OS level and used to build Docker
+images directly with the `docker` client, bypassing `docker-compose` entirely.
+This can be usefull to use alternative projects for building Docker images, as
+long as they implement a `docker`-compatible CLI interface, e.g. [img] or
+[nerdctl]. The shim is capable of translating the standard set of CLI options to
+the `build` command of `docker-compose`, to the specific set of options
+supported by the `build` command of the `docker`, `img` and `nerdctl` apps.
 
   [img]: https://github.com/genuinetools/img
   [nerdctl]: https://github.com/containerd/nerdctl

--- a/compose.sh
+++ b/compose.sh
@@ -359,11 +359,9 @@ cmd_build() {
 
 cmd_push() {
   # shellcheck disable=SC3043
-  local opt_ignore \
-        services || true
+  local services || true
 
   # Defaults
-  opt_ignore=0
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --ignore-push-failures)

--- a/compose.sh
+++ b/compose.sh
@@ -126,11 +126,14 @@ while [ "$#" -gt 0 ]; do
     -h | --help)  # Print help and return
       usage ;;
 
+    --)
+      shift; break;;
+
     -*)
       ERROR "${1%=*} unknown option!" >&2; usage 1;;
 
     *)
-      break
+      break;;
   esac
 done
 
@@ -182,7 +185,8 @@ cmd_build() {
         opt_quiet \
         line \
         build_args \
-        client_version || true
+        client_version \
+        services || true
 
   # Defaults
   opt_pull=0
@@ -236,11 +240,21 @@ cmd_build() {
         rm -f "$build_args"
         _cmd_usage "cmd_build" "build command will build or rebuild services from compose file" ;;
 
-      *)
+      --)
+        shift; break;;
+
+      -*)
         rm -f "$build_args"
         ERROR "${1%=*} unknown option!" >&2; _cmd_usage "cmd_build" "build command will build or rebuild services from compose file";;
+
+      *)
+        break;;
     esac
   done
+
+  # Capture list of services and reset argument list
+  services="$*"
+  set --
 
   # Get the short Docker client version. This also prints a unique identifier
   # for the type of the client, which is the reason why we are interested in the
@@ -324,6 +338,7 @@ cmd_build() {
     exec "$COMPOSE_SHIM" \
       -f "$COMPOSE_FILE" \
       -b "auto" \
+      -s "$services" \
       -i "" \
       -c "" \
       -a -1 \
@@ -333,12 +348,73 @@ cmd_build() {
     exec "$COMPOSE_SHIM" \
       -f "$COMPOSE_FILE" \
       -b "auto" \
+      -s "$services" \
       -i "" \
       -c "" \
       -a -1 \
       -- "$@"
   fi
 }
+
+
+cmd_push() {
+  # shellcheck disable=SC3043
+  local opt_ignore \
+        services || true
+
+  # Defaults
+  opt_ignore=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --ignore-push-failures)
+        ERROR "$1 not implemented"; shift;;
+
+      -h | --help)   # Print help and return
+        _cmd_usage "cmd_push" "Push service images" ;;
+
+      --)
+        shift; break;;
+
+      -*)
+        ERROR "${1%=*} unknown option!" >&2; _cmd_usage "cmd_push" "Push service images";;
+
+      *)
+        break;;
+    esac
+  done
+
+  # Capture list of services and reset argument list
+  services="$*"
+  set --
+
+  # Now set/export relevant variables and pass further everything to the underlying
+  # implementation.
+  BUILD_COMPOSE_BIN=
+  export DOCKER_HOST BUILD_COMPOSE_BIN BUILD_DOCKER_BIN
+  if [ "$COMPOSE_VERBOSE" -gt 0 ]; then
+    exec "$COMPOSE_SHIM" \
+      -f "$COMPOSE_FILE" \
+      -b "" \
+      -s "$services" \
+      -p \
+      -i "" \
+      -c "" \
+      -a -1 \
+      -v \
+      -- "$@"
+  else
+    exec "$COMPOSE_SHIM" \
+      -f "$COMPOSE_FILE" \
+      -b "" \
+      -s "$services" \
+      -p \
+      -i "" \
+      -c "" \
+      -a -1 \
+      -- "$@"
+  fi
+}
+
 
 cmd__build() {
   if [ "$COMPOSE_VERBOSE" -gt 0 ]; then


### PR DESCRIPTION
This implements the `push` command in the shim, using the `build.sh` script instead. This also adds supports for building/pushing some services only.

Close #27 